### PR TITLE
correcting spelling errors

### DIFF
--- a/tex/12-cassys_FR_utf8.tex
+++ b/tex/12-cassys_FR_utf8.tex
@@ -96,8 +96,8 @@ La fenêtre de configuration de CasSys (\ref{fig13-03}) comporte trois parties :
 		une info-bulle apparaît avec le chemin complet du graphe.
 		Les graphes dont le fichier source n'est pas trouvé apparaissent en italique et en rouge.
 
-	\item \textbf{Merge}: Si le transducer doit être appliqué en mode merge.
-	\item \textbf{Replace}: Si le transducer doit être appliqué en mode replace.
+	\item \textbf{Merge}: Si le transducteur doit être appliqué en mode merge.
+	\item \textbf{Replace}: Si le transducteur doit être appliqué en mode replace.
 	\item \textbf{Until fix point}: Si le transducteur doit être appliqué une fois ou plusieurs fois
 		jusqu'à ce que le texte soit inchangé c'est à dire qu'un point fixe est atteint (voir \ref{sub:AppWhiCon}).
 	\end{itemize}
@@ -451,7 +451,7 @@ Si on veut compl\'{e}ter la sortie du graphe par quelque chose qui ne doit pas \
   \label{fig12-3-07}
 \end{figure}
 
-\large{\textbf{Attention :}}  Si le graphe comporte plusieurs chemins, la bo\^{i}te avec \$G doit être répéter sur chaque chemin.
+\large{\textbf{Attention :}}  Si le graphe comporte plusieurs chemins, la bo\^{i}te avec \$G doit être répétée sur chaque chemin.
 
 \section{Les résultats d'une cascade}
 


### PR DESCRIPTION
correcting spelling errors in the French manual in the CasSys chapter.
This closes #9 .